### PR TITLE
feat(ios): support LiveView

### DIFF
--- a/iphone/Resources/hyperloop/hyperloop.bootstrap.js
+++ b/iphone/Resources/hyperloop/hyperloop.bootstrap.js
@@ -1,0 +1,2 @@
+// This file will be overwritten by hyperloop build hook if at least 1 native class was detected in app.
+// Will provide require/import bindings between native type name to hyperloop generated JS file.

--- a/iphone/hooks/generate/index.js
+++ b/iphone/hooks/generate/index.js
@@ -213,6 +213,7 @@ function generateFromJSON(name, json, state, callback, includes) {
 
 		processProtocolInheritance(json.protocols);
 
+		var modules = {};
 		var sourceSet = {
 			classes: {},
 			structs: {},
@@ -242,6 +243,7 @@ function generateFromJSON(name, json, state, callback, includes) {
 				});
 			}
 			sourceSet.classes[k] = genclass.generate(json, cls, state);
+			makeModule(modules, cls, state);
 		});
 
 		// structs
@@ -254,8 +256,6 @@ function generateFromJSON(name, json, state, callback, includes) {
 			sourceSet.structs[k] = genstruct.generate(json, struct);
 		});
 
-		// modules
-		var modules = {};
 		// define module based functions
 		json.functions && Object.keys(json.functions).forEach(function (k) {
 			var func = json.functions[k];

--- a/iphone/hooks/generate/module.js
+++ b/iphone/hooks/generate/module.js
@@ -4,8 +4,6 @@
  */
 'use strict';
 const util = require('./util');
-const path = require('path');
-const fs = require('fs');
 
 function makeModule(json, module, state) {
 	var entry = {
@@ -15,7 +13,8 @@ function makeModule(json, module, state) {
 			class_methods: [],
 			obj_class_method: [],
 			static_variables: {},
-			blocks: module.blocks
+			blocks: module.blocks,
+			nested_types: {}
 		},
 		framework: module.framework,
 		filename: module.filename,
@@ -57,6 +56,20 @@ function makeModule(json, module, state) {
 			entry.class.obj_class_method.push(code);
 		}
 	});
+
+	// Make framework's classes and structs available via the JS module's properties.
+	const copyNestedTypes = (sourceTypes) => {
+		if (sourceTypes) {
+			for (const typeName in sourceTypes) {
+				const typeInfo = sourceTypes[typeName];
+				if ((typeInfo.framework === module.framework) && (typeName !== module.name)) {
+					entry.class.nested_types[typeName] = typeInfo;
+				}
+			}
+		}
+	};
+	copyNestedTypes(json.classes);
+	copyNestedTypes(json.structs);
 
 	entry.renderedImports = util.makeImports(json, entry.imports);
 	return entry;

--- a/iphone/hooks/generate/templates/class.ejs
+++ b/iphone/hooks/generate/templates/class.ejs
@@ -195,4 +195,10 @@ Object.setPrototypeOf = Object.setPrototypeOf || function(obj, proto) {
 	return obj;
 }
 
+Object.defineProperty(<%= data.class.name %>, '<%= data.class.name %>', {
+	value: <%= data.class.name %>,
+	enumerable: false,
+	writable: false
+});
+
 module.exports = <%= data.class.name %>;

--- a/iphone/hooks/generate/templates/module.ejs
+++ b/iphone/hooks/generate/templates/module.ejs
@@ -75,6 +75,27 @@ keys.forEach(function (k, index) { %>
 });
 <% } -%>
 
+<% if (data.class.nested_types && Object.keys(data.class.nested_types).length) { -%>
+// framework classes and structs
+Object.defineProperties(<%= data.class.name %>, {
+<% var keys = Object.keys(data.class.nested_types);
+keys.forEach(function (nestedTypeName, index) { %>
+	<%=nestedTypeName%>: {
+		get: function() {
+			return require('/hyperloop/<%= data.framework.toLowerCase() %>/<%= nestedTypeName.toLowerCase() %>');
+		},
+		enumerable: true
+	}<%=index + 1 < keys.length ? ',':''%>
+<% }) %>
+});
+<% } -%>
+
 <% if (!data.excludeHeader) { -%>
+Object.defineProperty(<%= data.class.name %>, '<%= data.class.name %>', {
+	value: <%= data.class.name %>,
+	enumerable: false,
+	writable: false
+});
+
 module.exports = <%= data.class.name %>;
 <% } -%>

--- a/iphone/hooks/generate/templates/struct.ejs
+++ b/iphone/hooks/generate/templates/struct.ejs
@@ -57,4 +57,10 @@ function $initialize () {
 	$init = true;
 }
 
+Object.defineProperty(<%= data.class.name %>, '<%= data.class.name %>', {
+	value: <%= data.class.name %>,
+	enumerable: false,
+	writable: false
+});
+
 module.exports = <%= data.class.name %>;

--- a/iphone/hooks/generate/util.js
+++ b/iphone/hooks/generate/util.js
@@ -1267,41 +1267,6 @@ function resolveArg (metabase, imports, arg) {
 	}
 }
 
-/**
- * Gets a mapping of all classes and their properties that are affected by
- * the UIKIT_DEFINE_AS_PROPERTIES or FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST
- * macros.
- *
- * UIKIT_DEFINE_AS_PROPERTIES and FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST introduce
- * new readonly properties in favor of methods with the same name. This changes
- * how one would access them in Hyperloop.
- *
- * For example:
- *
- *  // < Hyperloop 2.0.0, as method
- *  var color = UIColor.redColor();
- *  // >= Hyperloop 2.0.0, as property (note the missing parenthesis)
- *  var color = UIColor.redColor;
- *
- * @return {Object} Contains a mapping of class names and their affected properties
- */
-function getMethodTableForMigration() {
-	var migrationFilename = 'migration-20161014143619.json';
-
-	if (getMethodTableForMigration.cachedTable) {
-		return getMethodTableForMigration.cachedTable;
-	}
-
-	var migrationPathAndFilename = path.resolve(__dirname, path.join('../../data', migrationFilename));
-	if (fs.existsSync(migrationPathAndFilename)) {
-		getMethodTableForMigration.cachedTable = JSON.parse(fs.readFileSync(migrationPathAndFilename).toString());
-	} else {
-		getMethodTableForMigration.cachedTable = {};
-	}
-
-	return getMethodTableForMigration.cachedTable;
-}
-
 exports.repeat = repeat;
 exports.generateTemplate = generateTemplate;
 exports.makeImports = makeImports;
@@ -1327,7 +1292,6 @@ exports.camelCase = camelCase;
 exports.resolveArg = resolveArg;
 exports.toValueDefault = toValueDefault;
 exports.isPrimitive = isPrimitive;
-exports.getMethodTableForMigration = getMethodTableForMigration;
 
 Object.defineProperty(exports, 'logger', {
 	get: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperloop",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperloop",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "UNLICENSED",
       "devDependencies": {
         "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28461

**Summary:**
- Support running LiveView with Hyperloop.
  * No longer modifies JS files containing Hyperloop requires/imports. _(This was the issue.)_
  * Now injects a `hyperloop.bootstrap.js` providing bindings between native types to JS files.
  * Implemented the same way as Android, which supports LiveView as of Titanium 9.0.0.
- Removed 3 year old native property access migration code.
- Updated module version to 7.0.2.

**Note:**
The following still won't work with LiveView because they require a native rebuild.
- Adding libraries.
- Adding `Hyperloop.defineClass()` calls. _(Because it involves native code generation.)_

---
**Test:**
1. Add this PR's hyperloop module to [hyperloop-examples](https://github.com/appcelerator/hyperloop-examples).
2. Build and run view LiveView: `appc run -p ios --liveview`
3. Go to every window in the example app and verify it works as expected.
4. While LiveView is running, open file: `hyperloop-examples/app/controllers/ios/label.js`
5. Change variable `infoString` from `'We ♥ iOS'` to `'We ♥ LiveView'` and save.
6. Verify app restarts without error.
7. Go to the app's Label window and verify the text has been updated.
